### PR TITLE
Some other fixes found 

### DIFF
--- a/lib/Doctrine/Migrations/AbstractMigration.php
+++ b/lib/Doctrine/Migrations/AbstractMigration.php
@@ -13,6 +13,7 @@ use Doctrine\Migrations\Exception\IrreversibleMigration;
 use Doctrine\Migrations\Exception\SkipMigration;
 use Psr\Log\LoggerInterface;
 use function func_get_args;
+use function sprintf;
 
 /**
  * The AbstractMigration class is for end users to extend from when creating migrations. Extend this class
@@ -111,7 +112,10 @@ abstract class AbstractMigration
 
     abstract public function up(Schema $schema) : void;
 
-    abstract public function down(Schema $schema) : void;
+    public function down(Schema $schema) : void
+    {
+        $this->abortIf(true, sprintf('No down() migration provided for "%s"', static::class));
+    }
 
     /**
      * @param mixed[] $params

--- a/lib/Doctrine/Migrations/DependencyFactory.php
+++ b/lib/Doctrine/Migrations/DependencyFactory.php
@@ -75,6 +75,11 @@ class DependencyFactory
         $this->em            = $em;
     }
 
+    public function setLogger(LoggerInterface $logger) : void
+    {
+        $this->logger = $logger;
+    }
+
     public function getConfiguration() : Configuration
     {
         return $this->configuration;

--- a/lib/Doctrine/Migrations/DependencyFactory.php
+++ b/lib/Doctrine/Migrations/DependencyFactory.php
@@ -65,6 +65,10 @@ class DependencyFactory
 
     public function __construct(Configuration $configuration, Connection $connection, ?EntityManagerInterface $em = null, ?LoggerInterface $logger = null)
     {
+        if ($configuration->getMetadataStorageConfiguration() instanceof MetadataStorageConfigration) {
+            $this->setMetadataStorageConfiguration($configuration->getMetadataStorageConfiguration());
+        }
+
         $this->configuration = $configuration;
         $this->logger        = $logger ?: new NullLogger();
         $this->connection    = $connection;

--- a/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
+++ b/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorage.php
@@ -130,7 +130,7 @@ final class TableMetadataStorage implements MetadataStorage
             $this->connection->insert($this->configuration->getTableName(), [
                 $this->configuration->getVersionColumnName() => (string) $result->getVersion(),
                 $this->configuration->getExecutedAtColumnName() => $result->getExecutedAt(),
-                $this->configuration->getExecutionTimeColumnName() => $result->getTime(),
+                $this->configuration->getExecutionTimeColumnName() => $result->getTime() === null ? null : (int) $result->getTime(),
             ], [
                 Type::STRING,
                 Type::DATETIME,

--- a/lib/Doctrine/Migrations/SchemaDumper.php
+++ b/lib/Doctrine/Migrations/SchemaDumper.php
@@ -76,7 +76,8 @@ class SchemaDumper
         string $fqcn,
         array $excludedTablesRegexes = [],
         bool $formatted = false,
-        int $lineLength = 120
+        int $lineLength = 120,
+        bool $includeDownMigration = false
     ) : string {
         $schema = $this->schemaManager->createSchema();
 
@@ -100,6 +101,9 @@ class SchemaDumper
                 $up[] = $upCode;
             }
 
+            if (! $includeDownMigration) {
+                continue;
+            }
             $downSql = [$this->platform->getDropTableSQL($table)];
 
             $downCode = $this->migrationSqlGenerator->generate(
@@ -119,13 +123,14 @@ class SchemaDumper
             throw NoTablesFound::new();
         }
 
-        $up   = implode("\n", $up);
-        $down = implode("\n", $down);
+        $up = implode("\n", $up);
 
         return $this->migrationGenerator->generateMigration(
             $fqcn,
             $up,
-            $down
+            null,
+            null,
+            $includeDownMigration ? null : ''
         );
     }
 

--- a/lib/Doctrine/Migrations/Tools/Console/Command/DumpSchemaCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/DumpSchemaCommand.php
@@ -73,6 +73,12 @@ EOT
                 InputOption::VALUE_OPTIONAL,
                 'Max line length of unformatted lines.',
                 120
+            )
+            ->addOption(
+                'with-down-migration',
+                null,
+                InputOption::VALUE_NONE,
+                'Generate down() migrations.'
             );
     }
 
@@ -83,8 +89,9 @@ EOT
         InputInterface $input,
         OutputInterface $output
     ) : ?int {
-        $formatted  = $input->getOption('formatted');
-        $lineLength = (int) $input->getOption('line-length');
+        $formatted            = $input->getOption('formatted');
+        $lineLength           = (int) $input->getOption('line-length');
+        $includeDownMigration = $input->getOption('with-down-migration');
 
         $schemaDumper = $this->getDependencyFactory()->getSchemaDumper();
         $versions     = $this->getDependencyFactory()->getMigrationRepository()->getMigrations();
@@ -116,7 +123,8 @@ EOT
             $fqcn,
             $input->getOption('filter-tables'),
             $formatted,
-            $lineLength
+            $lineLength,
+            $includeDownMigration === true
         );
 
         $editorCommand = $input->getOption('editor-cmd');

--- a/lib/Doctrine/Migrations/Tools/Console/Command/GenerateCommand.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Command/GenerateCommand.php
@@ -38,6 +38,12 @@ class GenerateCommand extends AbstractCommand
                 InputOption::VALUE_REQUIRED,
                 'The namespace to use for the migration (must be in the list of configured namespaces)'
             )
+            ->addOption(
+                'with-down-migration',
+                null,
+                InputOption::VALUE_NONE,
+                'Generate down() migrations.'
+            )
             ->setHelp(<<<EOT
 The <info>%command.name%</info> command generates a blank migration class:
 
@@ -58,7 +64,8 @@ EOT
 
         $migrationGenerator = $this->getDependencyFactory()->getMigrationGenerator();
 
-        $namespace = $input->getOption('namespace') ?: null;
+        $namespace            = $input->getOption('namespace') ?: null;
+        $includeDownMigration = $input->getOption('with-down-migration');
 
         $dirs = $configuration->getMigrationDirectories();
         if ($namespace === null) {
@@ -70,7 +77,13 @@ EOT
 
         $fqcn = $this->getDependencyFactory()->getClassNameGenerator()->generateClassName($namespace);
 
-        $path = $migrationGenerator->generateMigration($fqcn);
+        $path = $migrationGenerator->generateMigration(
+            $fqcn,
+            null,
+            null,
+            null,
+            $includeDownMigration ? null : ''
+        );
 
         $editorCommand = $input->getOption('editor-cmd');
 

--- a/lib/Doctrine/Migrations/Tools/Console/Exception/SchemaDumpRequiresNoMigrations.php
+++ b/lib/Doctrine/Migrations/Tools/Console/Exception/SchemaDumpRequiresNoMigrations.php
@@ -5,11 +5,15 @@ declare(strict_types=1);
 namespace Doctrine\Migrations\Tools\Console\Exception;
 
 use RuntimeException;
+use function sprintf;
 
 final class SchemaDumpRequiresNoMigrations extends RuntimeException implements ConsoleException
 {
-    public static function new() : self
+    public static function new(string $namespace) : self
     {
-        return new self('Delete any previous migrations before dumping your schema.');
+        return new self(sprintf(
+            'Delete any previous migrations in the namespace "%s" before dumping your schema.',
+            $namespace
+        ));
     }
 }

--- a/lib/Doctrine/Migrations/Version/Executor.php
+++ b/lib/Doctrine/Migrations/Version/Executor.php
@@ -331,9 +331,9 @@ final class Executor implements ExecutorInterface
             $this->outputSqlQuery($key, $query);
 
             if (! isset($this->params[$key])) {
-                $this->connection->executeQuery($query);
+                $this->connection->executeUpdate($query);
             } else {
-                $this->connection->executeQuery($query, $this->params[$key], $this->types[$key]);
+                $this->connection->executeUpdate($query, $this->params[$key], $this->types[$key]);
             }
 
             $stopwatchEvent->stop();

--- a/lib/Doctrine/Migrations/Version/Executor.php
+++ b/lib/Doctrine/Migrations/Version/Executor.php
@@ -225,11 +225,6 @@ final class Executor implements ExecutorInterface
 
         $result->setTime($stopwatchEvent->getDuration());
         $result->setMemory($stopwatchEvent->getMemory());
-        $plan->markAsExecuted($result);
-
-        if (! $configuration->isDryRun()) {
-            $this->metadataStorage->complete($result);
-        }
 
         $params = [
             'version' => (string) $plan->getVersion(),
@@ -240,11 +235,16 @@ final class Executor implements ExecutorInterface
 
         $this->logger->info('Migration {version} {direction} (took {time}ms, used {memory} memory)', $params);
 
+        if (! $configuration->isDryRun()) {
+            $this->metadataStorage->complete($result);
+        }
+
         if ($migration->isTransactional()) {
             //commit only if running in transactional mode
             $this->connection->commit();
         }
 
+        $plan->markAsExecuted($result);
         $result->setState(State::NONE);
 
         $this->dispatcher->dispatchVersionEvent(
@@ -279,21 +279,19 @@ final class Executor implements ExecutorInterface
 
     private function migrationEnd(Throwable $e, MigrationPlan $plan, ExecutionResult $result, MigratorConfiguration $configuration) : void
     {
+        $migration = $plan->getMigration();
+        if ($migration->isTransactional()) {
+            //only rollback transaction if in transactional mode
+            $this->connection->rollBack();
+        }
+
         $plan->markAsExecuted($result);
         $this->logResult($e, $result, $plan);
-
         $this->dispatcher->dispatchVersionEvent(
             Events::onMigrationsVersionSkipped,
             $plan,
             $configuration
         );
-
-        $migration = $plan->getMigration();
-
-        if ($migration->isTransactional()) {
-            //only rollback transaction if in transactional mode
-            $this->connection->rollBack();
-        }
 
         if ($configuration->isDryRun() || $result->isSkipped() || $result->hasError()) {
             return;

--- a/tests/Doctrine/Migrations/Tests/Configuration/Loader/AbstractLoaderTest.php
+++ b/tests/Doctrine/Migrations/Tests/Configuration/Loader/AbstractLoaderTest.php
@@ -17,6 +17,25 @@ abstract class AbstractLoaderTest extends TestCase
 {
     abstract public function load(string $prefix = '') : Configuration;
 
+    public function testLoadMinimal() : void
+    {
+        $config = $this->load('minimal');
+
+        self::assertNull($config->getName());
+        self::assertSame(['DoctrineMigrationsTest' => dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files'], $config->getMigrationDirectories());
+
+        self::assertSame([], $config->getMigrationClasses());
+
+        $storage = $config->getMetadataStorageConfiguration();
+        self::assertInstanceOf(TableMetadataStorageConfiguration::class, $storage);
+
+        self::assertSame('doctrine_migration_versions', $storage->getTableName());
+        self::assertSame('version', $storage->getVersionColumnName());
+        self::assertSame(1024, $storage->getVersionColumnLength());
+        self::assertSame('execution_time', $storage->getExecutionTimeColumnName());
+        self::assertSame('executed_at', $storage->getExecutedAtColumnName());
+    }
+
     public function testLoad() : void
     {
         $config = $this->load();

--- a/tests/Doctrine/Migrations/Tests/Configuration/_files/config_minimal.json
+++ b/tests/Doctrine/Migrations/Tests/Configuration/_files/config_minimal.json
@@ -1,0 +1,5 @@
+{
+    "migrations_paths" : {
+        "DoctrineMigrationsTest": "."
+    }
+}

--- a/tests/Doctrine/Migrations/Tests/Configuration/_files/config_minimal.php
+++ b/tests/Doctrine/Migrations/Tests/Configuration/_files/config_minimal.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'migrations_paths'      => ['DoctrineMigrationsTest' => '.'],
+];

--- a/tests/Doctrine/Migrations/Tests/Configuration/_files/config_minimal.xml
+++ b/tests/Doctrine/Migrations/Tests/Configuration/_files/config_minimal.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doctrine-migrations xmlns="http://doctrine-project.org/schemas/migrations/configuration/3.0"
+                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                     xsi:schemaLocation="http://doctrine-project.org/schemas/migrations/configuration/3.0
+                    http://doctrine-project.org/schemas/migrations/configuration/3.0.xsd">
+
+<migrations-paths>
+    <path namespace="DoctrineMigrationsTest">.</path>
+</migrations-paths>
+
+</doctrine-migrations>
+
+

--- a/tests/Doctrine/Migrations/Tests/Configuration/_files/config_minimal.yml
+++ b/tests/Doctrine/Migrations/Tests/Configuration/_files/config_minimal.yml
@@ -1,0 +1,3 @@
+---
+migrations_paths:
+  DoctrineMigrationsTest: .

--- a/tests/Doctrine/Migrations/Tests/SchemaDumperTest.php
+++ b/tests/Doctrine/Migrations/Tests/SchemaDumperTest.php
@@ -72,6 +72,44 @@ class SchemaDumperTest extends TestCase
             ->method('getCreateTableSQL')
             ->willReturn(['CREATE TABLE test']);
 
+        $this->platform->expects(self::never())
+            ->method('getDropTableSQL')
+            ->willReturn('DROP TABLE test');
+
+        $this->migrationSqlGenerator->expects(self::once())
+            ->method('generate')
+            ->with(['CREATE TABLE test'])
+            ->willReturn('up');
+
+        $this->migrationGenerator->expects(self::once())
+            ->method('generateMigration')
+            ->with('Foo\\1234', 'up', null, null, '')
+            ->willReturn('/path/to/migration.php');
+
+        self::assertSame('/path/to/migration.php', $this->schemaDumper->dump('Foo\\1234'));
+    }
+
+    public function testDumpWithDownMigration() : void
+    {
+        $table = $this->createMock(Table::class);
+        $table->expects(self::once())
+            ->method('getName')
+            ->willReturn('test');
+
+        $schema = $this->createMock(Schema::class);
+
+        $this->schemaManager->expects(self::once())
+            ->method('createSchema')
+            ->willReturn($schema);
+
+        $schema->expects(self::once())
+            ->method('getTables')
+            ->willReturn([$table]);
+
+        $this->platform->expects(self::once())
+            ->method('getCreateTableSQL')
+            ->willReturn(['CREATE TABLE test']);
+
         $this->platform->expects(self::once())
             ->method('getDropTableSQL')
             ->willReturn('DROP TABLE test');
@@ -88,10 +126,10 @@ class SchemaDumperTest extends TestCase
 
         $this->migrationGenerator->expects(self::once())
             ->method('generateMigration')
-            ->with('Foo\\1234', 'up', 'down')
+            ->with('Foo\\1234', 'up', null, null, '')
             ->willReturn('/path/to/migration.php');
 
-        self::assertSame('/path/to/migration.php', $this->schemaDumper->dump('Foo\\1234'));
+        self::assertSame('/path/to/migration.php', $this->schemaDumper->dump('Foo\\1234', [], false, 120, true));
     }
 
     public function testExcludedTableIsNotInTheDump() : void

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DumpSchemaCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DumpSchemaCommandTest.php
@@ -72,15 +72,20 @@ final class DumpSchemaCommandTest extends TestCase
 
         $input->expects(self::at(2))
             ->method('getOption')
+            ->with('with-down-migration')
+            ->willReturn(true);
+
+        $input->expects(self::at(3))
+            ->method('getOption')
             ->with('namespace')
             ->willReturn(null);
 
-        $input->expects(self::at(3))
+        $input->expects(self::at(4))
             ->method('getOption')
             ->with('filter-tables')
             ->willReturn(['/foo/']);
 
-        $input->expects(self::at(4))
+        $input->expects(self::at(5))
             ->method('getOption')
             ->with('editor-cmd')
             ->willReturn('test');

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DumpSchemaCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/DumpSchemaCommandTest.php
@@ -41,12 +41,12 @@ final class DumpSchemaCommandTest extends TestCase
     public function testExecuteThrowsRuntimeException() : void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Delete any previous migrations before dumping your schema.');
+        $this->expectExceptionMessage('Delete any previous migrations in the namespace "FooNs" before dumping your schema.');
 
         $input  = $this->createMock(InputInterface::class);
         $output = $this->createMock(OutputInterface::class);
 
-        $migration = new AvailableMigration(new Version('1'), $this->createMock(AbstractMigration::class));
+        $migration = new AvailableMigration(new Version('FooNs\Abc'), $this->createMock(AbstractMigration::class));
 
         $this->migrationRepository->expects(self::once())
             ->method('getMigrations')

--- a/tests/Doctrine/Migrations/Tests/Tools/Console/Command/GenerateCommandTest.php
+++ b/tests/Doctrine/Migrations/Tests/Tools/Console/Command/GenerateCommandTest.php
@@ -41,6 +41,11 @@ final class GenerateCommandTest extends TestCase
 
         $input->expects(self::at(1))
             ->method('getOption')
+            ->with('with-down-migration')
+            ->willReturn(true);
+
+        $input->expects(self::at(2))
+            ->method('getOption')
             ->with('editor-cmd')
             ->willReturn('mate');
 

--- a/tests/Doctrine/Migrations/Tests/Version/ExecutorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/ExecutorTest.php
@@ -112,6 +112,27 @@ class ExecutorTest extends TestCase
         ], $this->logger->logs);
     }
 
+    public function testExecuteUsedExecuteUpdate() : void
+    {
+        $this->connection
+            ->expects(self::never())
+            ->method('executeQuery');
+
+        $this->connection
+            ->expects(self::exactly(2))
+            ->method('executeUpdate');
+
+        $migratorConfiguration = (new MigratorConfiguration())
+            ->setTimeAllQueries(true);
+
+        $plan = new MigrationPlan($this->version, $this->migration, Direction::UP);
+
+        $this->versionExecutor->execute(
+            $plan,
+            $migratorConfiguration
+        );
+    }
+
     /**
      * @test
      */

--- a/tests/Doctrine/Migrations/Tests/Version/ExecutorTest.php
+++ b/tests/Doctrine/Migrations/Tests/Version/ExecutorTest.php
@@ -22,6 +22,7 @@ use Doctrine\Migrations\Version\ExecutionResult;
 use Doctrine\Migrations\Version\Executor;
 use Doctrine\Migrations\Version\State;
 use Doctrine\Migrations\Version\Version;
+use Exception;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Stopwatch\StopwatchEvent;
@@ -325,6 +326,78 @@ class ExecutorTest extends TestCase
             self::assertSame(State::EXEC, $result->getState());
             self::assertTrue($this->migration->preUpExecuted);
             self::assertFalse($this->migration->postUpExecuted);
+            self::assertFalse($this->migration->preDownExecuted);
+            self::assertFalse($this->migration->postDownExecuted);
+        }
+        self::assertFalse($migrationSucceed);
+    }
+
+    public function testChangesNotCommittedIfMetadataFailure() : void
+    {
+        $this->metadataStorage
+            ->expects(self::once())
+            ->method('complete')
+            ->willThrowException(new Exception('foo'));
+
+        $this->connection
+            ->expects(self::never())
+            ->method('commit');
+
+        $this->connection
+            ->expects(self::once())
+            ->method('rollBack');
+
+        $migratorConfiguration = (new MigratorConfiguration())
+            ->setTimeAllQueries(true);
+
+        $plan = new MigrationPlan($this->version, $this->migration, Direction::UP);
+
+        $listener = new class() {
+            /** @var bool */
+            public $onMigrationsVersionExecuting = false;
+            /** @var bool */
+            public $onMigrationsVersionExecuted = false;
+            /** @var bool */
+            public $onMigrationsVersionSkipped = false;
+
+            public function onMigrationsVersionExecuting() : void
+            {
+                $this->onMigrationsVersionExecuting = true;
+            }
+
+            public function onMigrationsVersionExecuted() : void
+            {
+                $this->onMigrationsVersionExecuted = true;
+            }
+
+            public function onMigrationsVersionSkipped() : void
+            {
+                $this->onMigrationsVersionSkipped = true;
+            }
+        };
+        $this->eventManager->addEventListener(Events::onMigrationsVersionExecuting, $listener);
+        $this->eventManager->addEventListener(Events::onMigrationsVersionExecuted, $listener);
+        $this->eventManager->addEventListener(Events::onMigrationsVersionSkipped, $listener);
+
+        $migrationSucceed = false;
+        try {
+            $this->versionExecutor->execute(
+                $plan,
+                $migratorConfiguration
+            );
+            $migrationSucceed = true;
+        } catch (Throwable $e) {
+            self::assertFalse($listener->onMigrationsVersionExecuted);
+            self::assertTrue($listener->onMigrationsVersionSkipped);
+            self::assertTrue($listener->onMigrationsVersionExecuting);
+
+            $result = $plan->getResult();
+            self::assertNotNull($result);
+            self::assertSame([], $result->getSql());
+            self::assertSame([], $result->getSql());
+            self::assertSame(State::POST, $result->getState());
+            self::assertTrue($this->migration->preUpExecuted);
+            self::assertTrue($this->migration->postUpExecuted);
             self::assertFalse($this->migration->preDownExecuted);
             self::assertFalse($this->migration->postDownExecuted);
         }


### PR DESCRIPTION
<!-- Fill in the relevant information below to help triage your pull request. -->

|      Q       |   A
|------------- | -----------
| Type         | bug/feature/improvement
| BC Break     | yes/no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary your change. -->
- ensure ExecutionTimeColumn is always an integer (this is a bug)
- allow dump schema when migrations in other namespaces are present (since we have multiple namespaces, makes sense to relax this rule per namespace)

